### PR TITLE
Fix update handler name to match the one defined in default vars

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: ca-certificates update (Debian)
+- name: update ca-certificates (Debian)
   command: /usr/sbin/update-ca-certificates
   when: ansible_os_family == 'Debian'
 
-- name: ca-certificates update (RedHat)
+- name: update ca-certificates (RedHat)
   command: /usr/bin/update-ca-trust
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | f-
| Related issues/PRs | -
| License | GPLv3

#### What's in this PR?

Fixes the update handler name to match the one defined in default vars.

#### Why?

Otherwise the playbook run fails..