### PR TITLE
static is depracated, use include_tasks instead

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: GPLv3
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.4
 
   platforms:
   - name: EL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,24 +10,20 @@
 
 - block:
   - name: Enable Cert Management (RHEL 6, Ansible < 2.2)
-    include: ca_certificates-RedHat-6-lt-2.2.yml
-    static: false
+    include_tasks: ca_certificates-RedHat-6-lt-2.2.yml
     when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '6'
 
   - name: Install Trusted (Ansible < 2.2)
-    include: ca_certificates-trusted-lt-2.2.yml
-    static: false
+    include_tasks: ca_certificates-trusted-lt-2.2.yml
   when: ansible_version['full'] | version_compare('2.2.0.0', operator='lt')
 
 - block:
   - name: Enable Cert Management (RHEL 6, Ansible >= 2.2)
-    include: ca_certificates-RedHat-6-ge-2.2.yml
-    static: false
+    include_tasks: ca_certificates-RedHat-6-ge-2.2.yml
     when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '6'
 
   - name: Install Trusted (Ansible >= 2.2)
-    include: ca_certificates-trusted-ge-2.2.yml
-    static: false
+    include_tasks: ca_certificates-trusted-ge-2.2.yml
   when: ansible_version['full'] | version_compare('2.2.0.0', operator='ge')
 
 - name: Update CA Certificates


### PR DESCRIPTION
Thanks for the awesome role @bdellegrazie :+1:  This commit uses `include_tasks` instead of static.
