### PR TITLE
fix: updating skipped when only one type of cert is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed issue where the update trigger is skipped
 ### Security
 
 ## [3.1.0] - 2020-01-11

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,6 @@
   become: true
   command: "{{ ca_certificates_handler }}"
   when:
-    - _ca_certificates_copied is changed
-    - _ca_certificates_written is changed
+    - _ca_certificates_copied is changed or
+      _ca_certificates_written is changed
     - ca_certificates_update | bool


### PR DESCRIPTION
This commit fixes the issue where the task "Update CA Certificates"
is skipped when only one type of installation is used (`pem` or
`remote_pem`).