### PR TITLE
Fix hyperlinks in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Minor linting changes
 
 [Unreleased]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v3.1.0..HEAD
-[v3.1.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v3.0.0..v3.1.0
-[v3.0.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v2.1.1..v3.0.0
-[v2.1.1]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v2.1.0..v2.1.1
-[v2.1.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v2.0.0..v2.1.0
-[v2.0.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v1.0.1..v2.0.0
-[v1.0.1]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v1.0.0..v1.0.1
-[v1.0.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v0.9.0..v1.0.0
-[v0.9.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/..v0.9.0
+[3.1.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v3.0.0..v3.1.0
+[3.0.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v2.1.1..v3.0.0
+[2.1.1]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v2.1.0..v2.1.1
+[2.1.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v2.0.0..v2.1.0
+[2.0.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v1.0.1..v2.0.0
+[1.0.1]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v1.0.0..v1.0.1
+[1.0.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/v0.9.0..v1.0.0
+[0.9.0]: https://github.com/bdellegrazie/ansible-role-ca-certificates/compare/..v0.9.0


### PR DESCRIPTION
The id of the hyperlinks are wrong in the CHANGELOG.md file.
This commit fixes the id to make hyperlinks work.